### PR TITLE
Add @stevegrossi’s dev blog

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -14,22 +14,23 @@ feeds:
 - http://feeds.feedburner.com/aaronbushnell
 - http://feeds.feedburner.com/codebtbytescom
 - http://feeds.feedburner.com/funkablog-atom
-- http://roadfiresoftware.com/blog/feed/
 - http://jacob.jkrall.net/rss.xml
 - http://joeldart.wordpress.com/feed/
 - http://jon-nolen.blogspot.com/feeds/posts/default
 - http://larry-price.com/atom.xml
 - http://mafellows.com/rss
 - http://massive-robot.blogspot.com/feeds/posts/default
-- http://www.mdswanson.com/atom.xml
 - http://mike-rogers.github.io/atom.xml
 - http://milamsoft.blogspot.com
 - http://mileszs.com/atom.xml
 - http://myotherpants.com/category/worksafe/feed/
 - http://pickardayune.com/atom.xml
+- http://roadfiresoftware.com/blog/feed/
 - http://softwaresaltmines.com/feed/
 - http://todd.grotenhuis.info/atom.xml
 - http://verticalaligncenter.com/blog?format=rss
+- http://work.stevegrossi.com/feed.xml
+- http://www.mdswanson.com/atom.xml
 - http://www.schmonz.com/rss/
 - https://codatory.com/rss/
 title: IndyHackers Planet


### PR DESCRIPTION
Hey, @stevegrossi from Indy.rb here. I'm an Indy hacker who writes about full-stack development with Ruby and Rails on my dev blog, and I'd love to have it included in the list.

This PR does just that, though it looks like the add_user.rb script did some realphabetization, too.
