### PR TITLE
including atom feeds

### DIFF
--- a/planet.rb
+++ b/planet.rb
@@ -48,7 +48,7 @@ class Feeds
   end
 
   def self.entries
-    @feeds.values.select{|i| i.is_a?(Feedjira::Parser::RSS)}.map(&:entries).flatten
+    @feeds.values.select{|i| i.is_a?(Feedjira::Parser::RSS) || i.is_a?(Feedjira::Parser::Atom)}.map(&:entries).flatten
   end
 
   def self.to_a


### PR DESCRIPTION
In reference to #13 - Atom feeds are not currently being included in the RSS feeds. This may be something that happened when Feedjira was updated, because I feel like it used to work.