### PR TITLE
Added RSS feed for "Creators Who Code"

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7,6 +7,7 @@ feeds:
 - https://aaron.milam.io/feed.xml
 - https://blog.grotenhuis.info/feed.xml
 - https://carloslem.us/blog/index.xml
+- https://creatorswhocode.com/feed.xml
 - https://dev.jimgrey.net/feed/
 - https://fuzzyblog.io/blog/feed.xml
 - https://jacob.jkrall.net/rss.xml


### PR DESCRIPTION
A feed for early-career developers in the Midwest 
who are focused on finding freedom in their careers

(typically 1.5 posts per month)